### PR TITLE
$scope.setUserContentStyles: append px to fontSize

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -397,7 +397,7 @@ app.controller('appController', function($scope, $http, $document, $timeout, app
   $scope.setUserContentStyles = function(fontFamily, fontSize, fontWeight, bgColor, color) {
     return {
       'font-family' : fontFamily,
-      'font-size' : fontSize,
+      'font-size' : fontSize + 'px',
       'font-weight' : fontWeight,
       'background-color' : bgColor,
       'color' : color


### PR DESCRIPTION
Assume we're using px since the input box defaults to a
number and px is listed in the input box label.

Signed-off-by: Ian Hilt ian.hilt@gmail.com
