### PR TITLE
fix: copy values

### DIFF
--- a/index.html
+++ b/index.html
@@ -263,7 +263,6 @@
       </div>
     </article>
 
-    <script type="text/javascript" src="js/vendor/ZeroClipboard.min.js"></script>
     <script src="https://squaresend.com/squaresend.js"></script>
 
     <script type="text/javascript" src="dist/js/vendorJS.min.js"></script>

--- a/js/app.js
+++ b/js/app.js
@@ -147,6 +147,7 @@ app.controller('appController', function($scope, $http, $document, $timeout, app
 
   $scope.showInstructions2 = function(color) {
     $scope.currentCopiedColor = color;
+    $scope.copyToClipbord($scope.colorModel.label, color)
     $scope.isInstructions2Active = true;
     $timeout(function() {
       $scope.fadeOutInstructions = true;
@@ -224,6 +225,12 @@ app.controller('appController', function($scope, $http, $document, $timeout, app
     //console.log('the currentColorFilter before destroy is: ', $scope.currentColorFilter);
   };
 
+  //Copy to clipboard
+  $scope.copyToClipbord = function (type, color) {
+    const valueToCopy = (type === 'rgb') ? `rgb(${color[type]})` : color[type];
+
+    return navigator.clipboard.writeText(valueToCopy);
+  }
 
   /**
    * On Scroll, pin toolbar to top when picking colors from tiles
@@ -412,8 +419,8 @@ app.controller('appController', function($scope, $http, $document, $timeout, app
   /**
    * Zero Clipboard plugin to copy to clipboard
    */
-  new ZeroClipboard( document.getElementById("copyHexValue") );
-  new ZeroClipboard( document.getElementById("copyRgbValue") );
+  //new ZeroClipboard( document.getElementById("copyHexValue") );
+  //new ZeroClipboard( document.getElementById("copyRgbValue") );
 
   /**
    * Sources of awesomeness:


### PR DESCRIPTION
### This is a great tool, and I was using it a lot so I hope can return the help.

Like it's mentionated in this [issue](https://github.com/donnieberg/accessible-color-palette/issues/11), copy values does not work for some people (me included).

So to fix it, I deleted the ZeroClipboard logic and writed code for use the native ClipboardAPI that have a good compatbility with the browsers.